### PR TITLE
ci: add docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+docs/
+dist/
+.github/
+
+.dockerignore
+.gitignore
+
+Makefile
+README.md
+LICENSE

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -26,3 +26,11 @@ jobs:
         run: sqlc vet
       - name: Diff
         run: sqlc diff
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,3 +21,24 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/crazybolillo/eryth
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.22
+
+WORKDIR /app
+
+COPY . .
+
+ENV CGO_ENABLED=0
+RUN go build -o /bin/eryth ./cmd
+
+FROM scratch
+
+COPY --from=0 /bin/eryth /bin/eryth
+
+ENTRYPOINT ["eryth"]


### PR DESCRIPTION
A docker image will be uploaded to github's registry on new releases, it is also built as part of the QA job to ensure no regressions.