### PR TITLE
feat: support display name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,17 +41,17 @@ func serve(ctx context.Context) error {
 		return fmt.Errorf("missing Database URL")
 	}
 
-	url, err := url.Parse(dbUrl)
+	u, err := url.Parse(dbUrl)
 	if err != nil {
 		slog.Error("Invalid database URL", "reason", err.Error())
 		return err
 	}
 	slog.Info(
 		"Connecting to database",
-		slog.String("host", url.Host),
-		slog.String("port", url.Port()),
-		slog.String("user", url.User.Username()),
-		slog.String("database", url.Path[1:]),
+		slog.String("host", u.Host),
+		slog.String("port", u.Port()),
+		slog.String("user", u.User.Username()),
+		slog.String("database", u.Path[1:]),
 	)
 
 	conn, err := pgx.Connect(ctx, os.Getenv("DATABASE_URL"))

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,6 +3,8 @@ definitions:
     properties:
       allow:
         type: boolean
+      callerid:
+        type: string
       destination:
         type: string
     type: object
@@ -21,6 +23,8 @@ definitions:
         type: array
       context:
         type: string
+      display_name:
+        type: string
       extension:
         type: string
       id:
@@ -34,21 +38,23 @@ definitions:
       transport:
         type: string
     type: object
-  handler.listEndpointsRequest:
-    properties:
-      endpoints:
-        items:
-          $ref: '#/definitions/sqlc.ListEndpointsRow'
-        type: array
-    type: object
-  sqlc.ListEndpointsRow:
+  handler.listEndpointEntry:
     properties:
       context:
+        type: string
+      display_name:
         type: string
       extension:
         type: string
       id:
         type: string
+    type: object
+  handler.listEndpointsRequest:
+    properties:
+      endpoints:
+        items:
+          $ref: '#/definitions/handler.listEndpointEntry'
+        type: array
     type: object
 host: localhost:8080
 info:
@@ -79,7 +85,8 @@ paths:
           description: Bad Request
         "500":
           description: Internal Server Error
-      summary: Determine whether the specified action (call) is allowed or not.
+      summary: Determine whether the specified action (call) is allowed or not and
+        provide details on how
       tags:
       - bouncer
   /endpoint:

--- a/internal/handler/authorization.go
+++ b/internal/handler/authorization.go
@@ -29,7 +29,8 @@ func (e *Authorization) Router() chi.Router {
 	return r
 }
 
-// @Summary Determine whether the specified action (call) is allowed or not.
+// @Summary Determine whether the specified action (call) is allowed or not and provide details on how
+// to accomplish it.
 // @Accept json
 // @Produce json
 // @Param payload body AuthorizationRequest true "Action to be reviewed"

--- a/internal/handler/endpoint_test.go
+++ b/internal/handler/endpoint_test.go
@@ -1,0 +1,44 @@
+package handler
+
+import "testing"
+
+func TestDisplayNameFromClid(t *testing.T) {
+	cases := map[string]struct {
+		callerID    string
+		displayName string
+	}{
+		"valid": {
+			`"Kiwi Snow" <kiwi99>`,
+			"Kiwi Snow",
+		},
+		"empty": {
+			"",
+			"",
+		},
+		"single_colon": {
+			`"`,
+			"",
+		},
+		"empty_quotes": {
+			`""`,
+			"",
+		},
+		"missing_start_quote": {
+			`John Smith" <john>`,
+			"",
+		},
+		"missing_end_quote": {
+			`"John Smith <john>`,
+			"",
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := displayNameFromClid(tt.callerID)
+			if got != tt.displayName {
+				t.Errorf("got %q, want %q", got, tt.displayName)
+			}
+		})
+	}
+}

--- a/queries.sql
+++ b/queries.sql
@@ -12,9 +12,9 @@ VALUES
 
 -- name: NewEndpoint :one
 INSERT INTO ps_endpoints
-    (id, transport, aors, auth, context, disallow, allow)
+    (id, transport, aors, auth, context, disallow, allow, callerid)
 VALUES
-    ($1, $2, $1, $1, $3, 'all', $4)
+    ($1, $2, $1, $1, $3, 'all', $4, $5)
 RETURNING sid;
 
 -- name: DeleteEndpoint :exec
@@ -28,7 +28,7 @@ DELETE FROM ps_auths WHERE id = $1;
 
 -- name: ListEndpoints :many
 SELECT
-    pe.id, pe.context, ee.extension
+    pe.id, pe.callerid, pe.context, ee.extension
 FROM
     ps_endpoints pe
 LEFT JOIN
@@ -44,10 +44,12 @@ VALUES
 
 -- name: GetEndpointByExtension :one
 SELECT
-    ps_endpoints.id
+    dest.id, src.callerid
 FROM
-    ps_endpoints
+    ps_endpoints dest
 INNER JOIN
-    ery_extension ee on ps_endpoints.sid = ee.endpoint_id
+    ery_extension ee ON dest.sid = ee.endpoint_id
+INNER JOIN
+    ps_endpoints src ON src.id = $1
 WHERE
-    ee.extension = $1;
+    ee.extension = $2;


### PR DESCRIPTION
Endpoints now have a display name which is used to build a proper caller
ID to be used when dialing internal users. This information is also
provided by the bouncer so Stasis apps know which caller ID to use for
calling the other party.

Closes https://github.com/crazybolillo/eryth/issues/8.