### PR TITLE
ref: plural URLs and camel case for JSON

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,7 +74,7 @@ func serve(ctx context.Context) error {
 	r.Use(middleware.AllowContentEncoding("application/json"))
 
 	endpoint := handler.Endpoint{Conn: conn}
-	r.Mount("/endpoint", endpoint.Router())
+	r.Mount("/endpoints", endpoint.Router())
 
 	checker := &bouncer.Bouncer{Conn: conn}
 	authorization := handler.Authorization{Bouncer: checker}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -23,13 +23,13 @@ definitions:
         type: array
       context:
         type: string
-      display_name:
+      displayName:
         type: string
       extension:
         type: string
       id:
         type: string
-      max_contacts:
+      maxContacts:
         type: integer
       password:
         type: string
@@ -42,7 +42,7 @@ definitions:
     properties:
       context:
         type: string
-      display_name:
+      displayName:
         type: string
       extension:
         type: string
@@ -89,7 +89,28 @@ paths:
         provide details on how
       tags:
       - bouncer
-  /endpoint:
+  /endpoints:
+    get:
+      parameters:
+      - default: 15
+        description: Limit the amount of endpoints returned
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.listEndpointsRequest'
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
+      summary: List existing endpoints.
+      tags:
+      - endpoints
     post:
       consumes:
       - application/json
@@ -110,7 +131,7 @@ paths:
       summary: Create a new endpoint.
       tags:
       - endpoints
-  /endpoint/{id}:
+  /endpoints/{id}:
     delete:
       parameters:
       - description: ID of the endpoint to be deleted
@@ -126,28 +147,6 @@ paths:
         "500":
           description: Internal Server Error
       summary: Delete an endpoint and its associated resources.
-      tags:
-      - endpoints
-  /endpoint/list:
-    get:
-      parameters:
-      - default: 15
-        description: Limit the amount of endpoints returned
-        in: query
-        name: limit
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/handler.listEndpointsRequest'
-        "400":
-          description: Bad Request
-        "500":
-          description: Internal Server Error
-      summary: List existing endpoints.
       tags:
       - endpoints
 swagger: "2.0"

--- a/internal/handler/endpoint.go
+++ b/internal/handler/endpoint.go
@@ -26,16 +26,16 @@ type createEndpointRequest struct {
 	Transport   string   `json:"transport,omitempty"`
 	Context     string   `json:"context"`
 	Codecs      []string `json:"codecs"`
-	MaxContacts int32    `json:"max_contacts,omitempty"`
+	MaxContacts int32    `json:"maxContacts,omitempty"`
 	Extension   string   `json:"extension,omitempty"`
-	DisplayName string   `json:"display_name"`
+	DisplayName string   `json:"displayName"`
 }
 
 type listEndpointEntry struct {
 	ID          string `json:"id"`
 	Extension   string `json:"extension"`
 	Context     string `json:"context"`
-	DisplayName string `json:"display_name"`
+	DisplayName string `json:"displayName"`
 }
 
 type listEndpointsRequest struct {
@@ -45,7 +45,7 @@ type listEndpointsRequest struct {
 func (e *Endpoint) Router() chi.Router {
 	r := chi.NewRouter()
 	r.Post("/", e.create)
-	r.Get("/list", e.list)
+	r.Get("/", e.list)
 	r.Delete("/{id}", e.delete)
 
 	return r
@@ -79,7 +79,7 @@ func displayNameFromClid(callerID string) string {
 // @Failure 400
 // @Failure 500
 // @Tags endpoints
-// @Router /endpoint/list [get]
+// @Router /endpoints [get]
 func (e *Endpoint) list(w http.ResponseWriter, r *http.Request) {
 	qlim := r.URL.Query().Get("limit")
 	limit := 15
@@ -137,7 +137,7 @@ func (e *Endpoint) list(w http.ResponseWriter, r *http.Request) {
 // @Failure 400
 // @Failure 500
 // @Tags endpoints
-// @Router /endpoint [post]
+// @Router /endpoints [post]
 func (e *Endpoint) create(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	payload := createEndpointRequest{
@@ -219,7 +219,7 @@ func (e *Endpoint) create(w http.ResponseWriter, r *http.Request) {
 // @Failure 400
 // @Failure 500
 // @Tags endpoints
-// @Router /endpoint/{id} [delete]
+// @Router /endpoints/{id} [delete]
 func (e *Endpoint) delete(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if id == "" {


### PR DESCRIPTION
Kind of annoying having to map typescript interfaces from snake_case to camel case when processing JSON from this API. It was considered better to just change the case from the source.

Plural URLs also lend themselves to shorter uses (no longer need a /list path) so they have been chosen.