### PR TITLE
feat(endpoint): nat & media_encryption attributes

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -27,12 +27,16 @@ definitions:
         type: string
       displayName:
         type: string
+      encryption:
+        type: string
       extension:
         type: string
       id:
         type: string
       maxContacts:
         type: integer
+      nat:
+        type: boolean
       sid:
         type: integer
       transport:
@@ -74,12 +78,16 @@ definitions:
         type: string
       displayName:
         type: string
+      encryption:
+        type: string
       extension:
         type: string
       id:
         type: string
       maxContacts:
         type: integer
+      nat:
+        type: boolean
       password:
         type: string
       transport:
@@ -95,10 +103,14 @@ definitions:
         type: string
       displayName:
         type: string
+      encryption:
+        type: string
       extension:
         type: string
       maxContacts:
         type: integer
+      nat:
+        type: boolean
       password:
         type: string
       transport:

--- a/internal/handler/endpoint_test.go
+++ b/internal/handler/endpoint_test.go
@@ -110,6 +110,7 @@ func MustCreate(handler http.Handler) func(*testing.T) {
 			Extension:   "1234",
 			DisplayName: "Zinnia Elegans",
 			MaxContacts: 10,
+			Nat:         true,
 		}
 		res := createEndpoint(t, handler, endpoint)
 		if res.Code != http.StatusCreated {
@@ -127,6 +128,7 @@ func MustCreate(handler http.Handler) func(*testing.T) {
 			Codecs:      endpoint.Codecs,
 			MaxContacts: 10,
 			Extension:   "1234",
+			Nat:         true,
 		}
 
 		if !reflect.DeepEqual(got, want) {
@@ -198,15 +200,21 @@ func MustUpdate(handler http.Handler) func(*testing.T) {
 			Codecs:      []string{"ulaw", "opus"},
 			Extension:   "5061",
 			DisplayName: "Big Chungus",
+			Nat:         false,
+			Encryption:  "dtls",
 		}
 		res := createEndpoint(t, handler, endpoint)
 		want := parseEndpoint(t, res.Body)
 		want.MaxContacts = 5
 		want.Extension = "6072"
+		want.Nat = true
+		want.Encryption = "sdes"
 
 		res = updateEndpoint(t, handler, want.Sid, model.PatchedEndpoint{
 			MaxContacts: &want.MaxContacts,
 			Extension:   &want.Extension,
+			Nat:         &want.Nat,
+			Encryption:  &want.Encryption,
 		})
 		if res.Code != http.StatusOK {
 			t.Errorf("invalid http code, got %d, want %d", res.Code, http.StatusOK)

--- a/internal/model/endpoint.go
+++ b/internal/model/endpoint.go
@@ -10,6 +10,8 @@ type Endpoint struct {
 	Codecs      []string `json:"codecs"`
 	MaxContacts int32    `json:"maxContacts"`
 	Extension   string   `json:"extension"`
+	Nat         bool     `json:"nat"`
+	Encryption  string   `json:"encryption"`
 }
 
 type NewEndpoint struct {
@@ -22,6 +24,8 @@ type NewEndpoint struct {
 	MaxContacts int32    `json:"maxContacts"`
 	Extension   string   `json:"extension"`
 	DisplayName string   `json:"displayName"`
+	Nat         bool     `json:"nat"`
+	Encryption  string   `json:"encryption"`
 }
 
 type PatchedEndpoint struct {
@@ -32,6 +36,8 @@ type PatchedEndpoint struct {
 	Codecs      []string `json:"codecs,"`
 	MaxContacts *int32   `json:"maxContacts,"`
 	Extension   *string  `json:"extension,"`
+	Nat         *bool    `json:"nat,"`
+	Encryption  *string  `json:"encryption,"`
 }
 
 type EndpointPageEntry struct {

--- a/queries.sql
+++ b/queries.sql
@@ -12,9 +12,23 @@ VALUES
 
 -- name: NewEndpoint :one
 INSERT INTO ps_endpoints
-    (id, transport, aors, auth, context, disallow, allow, callerid, accountcode)
+    (
+         id,
+         transport,
+         aors,
+         auth,
+         context,
+         disallow,
+         allow,
+         callerid,
+         accountcode,
+         force_rport,
+         rewrite_contact,
+         rtp_symmetric,
+         media_encryption
+    )
 VALUES
-    ($1, $2, $1, $1, $3, 'all', $4, $5, $6)
+    ($1, $2, $1, $1, $3, 'all', $4, $5, $6, @nat, @nat, @nat, $7)
 RETURNING sid;
 
 -- name: DeleteEndpoint :one
@@ -56,7 +70,16 @@ WHERE
 
 -- name: GetEndpointByID :one
 SELECT
-    pe.id, pe.accountcode, pe.callerid, pe.context, ee.extension, pe.transport, aor.max_contacts, pe.allow
+    pe.id,
+    pe.accountcode,
+    pe.callerid,
+    pe.context,
+    ee.extension,
+    pe.transport,
+    aor.max_contacts,
+    pe.allow,
+    (pe.force_rport::text::boolean AND pe.rewrite_contact::text::boolean AND pe.rtp_symmetric::text::boolean) AS nat,
+    pe.media_encryption
 FROM
     ps_endpoints pe
 INNER JOIN
@@ -76,9 +99,13 @@ SET
     callerid = $1,
     context = $2,
     transport = $3,
-    allow = $4
+    allow = $4,
+    force_rport = @nat,
+    rewrite_contact = @nat,
+    rtp_symmetric = @nat,
+    media_encryption = $5
 WHERE
-    sid = $5;
+    sid = $6;
 
 -- name: UpdateExtensionByEndpointId :exec
 UPDATE


### PR DESCRIPTION
A new NAT parameter can be set on endpoints. It abstracts away the necessary modifications to endpoint fields required for a far end NAT phone to work with asterisk.

Support for setting media_encryption attributes on endpoints was also added, however DTLS needs more configuration which so far has not been implemented so in practical terms only sdes will work through eryth.

Closes #26.
Related to #23.