### PR TITLE
feat: support external callers

### DIFF
--- a/internal/service/bouncer.go
+++ b/internal/service/bouncer.go
@@ -32,9 +32,16 @@ func (b *Bouncer) Check(ctx context.Context, endpoint, dialed string) model.Boun
 		return result
 	}
 
+	var callerId string
+	if row.Callerid.Valid {
+		callerId = row.Callerid.String
+	} else {
+		callerId = endpoint
+	}
+
 	return model.BouncerResponse{
 		Allow:       true,
 		Destination: row.ID,
-		CallerID:    row.Callerid.String,
+		CallerID:    callerId,
 	}
 }

--- a/internal/sqlc/queries.sql.go
+++ b/internal/sqlc/queries.sql.go
@@ -84,7 +84,7 @@ FROM
     ps_endpoints dest
 INNER JOIN
     ery_extension ee ON dest.sid = ee.endpoint_id
-INNER JOIN
+LEFT JOIN
     ps_endpoints src ON src.id = $1
 WHERE
     ee.extension = $2

--- a/queries.sql
+++ b/queries.sql
@@ -63,7 +63,7 @@ FROM
     ps_endpoints dest
 INNER JOIN
     ery_extension ee ON dest.sid = ee.endpoint_id
-INNER JOIN
+LEFT JOIN
     ps_endpoints src ON src.id = $1
 WHERE
     ee.extension = $2;


### PR DESCRIPTION
When receiving calls from external callers (usually from PSTN) the endpoint won't be found, this would previously result in calls not being allowed. The logic has been changed to support this use case.